### PR TITLE
deploy-spawner.sh: Update to spawner v3.0.5

### DIFF
--- a/scripts/deploy-spawner.sh
+++ b/scripts/deploy-spawner.sh
@@ -9,7 +9,7 @@ fail()
 WORKSHOP_IMAGE="quay.io/openshiftlabs/lab-mysql-operator:latest"
 
 TEMPLATE_REPO=https://raw.githubusercontent.com/openshift-labs/workshop-spawner
-TEMPLATE_VERSION=3.0.3
+TEMPLATE_VERSION=3.0.5
 TEMPLATE_FILE=learning-portal-production.json
 TEMPLATE_PATH=$TEMPLATE_REPO/$TEMPLATE_VERSION/templates/$TEMPLATE_FILE
 


### PR DESCRIPTION
tested on RHPDS OCP v3.11, with 2.10.3 dashboard